### PR TITLE
[a11y] Use (invisible) cursor to indicate focus

### DIFF
--- a/samples/mywork/Panes/FileMgr.hs
+++ b/samples/mywork/Panes/FileMgr.hs
@@ -18,6 +18,7 @@ module Panes.FileMgr
 where
 
 import           Brick hiding ( Location )
+import qualified Brick (Location(..))
 import           Brick.Panes
 import           Brick.Widgets.Center
 import qualified Brick.Widgets.Core as BC
@@ -110,7 +111,8 @@ drawFB ds b =
                                   $ strWrap
                                   $ X.displayException e
       savePane = (if fcsd == Just WFSaveBtn
-                  then withAttr (attrName "Selected")
+                  then withAttr (attrName "Selected") .
+                       putCursor WFSaveBtn (Brick.Location (1,0))
                   else id)
                  $ str "[SAVE]"
   in centerLayer (browserPane b <=> errDisplay b <=> savePane <=> helpPane)


### PR DESCRIPTION
Although this is just an example application, it should set a good example.
Screen readers heavily rely on the cursor location to let the user know
what is currently selected.  To that end, the putCursor Brick API has been
added to make it possible to put an (invisible) cursor on a (focused) widget.
