### PR TITLE
bumping up versions so that it uses lates brick, vty

### DIFF
--- a/brick-panes.cabal
+++ b/brick-panes.cabal
@@ -47,11 +47,11 @@ library
     hs-source-dirs:   src
     default-language: Haskell2010
     exposed-modules:  Brick.Panes
-    build-depends:    base >= 4.13 && < 4.18
-                    , brick >= 1.0 && < 1.7
+    build-depends:    base >= 4.13 && < 5
+                    , brick >= 1.0 && < 2.4
                     , containers
                     , microlens >= 0.4.11.2 && < 0.5
-                    , vty >= 5.35 && < 5.39
+                    , vty >= 5.35 && < 6.2
 
 executable mywork-example
     import:           settings
@@ -68,10 +68,10 @@ executable mywork-example
                       Panes.Summary
                       Paths_brick_panes
     autogen-modules:  Paths_brick_panes
-    build-depends:    base >= 4.13 && < 4.18
+    build-depends:    base >= 4.13 && < 5
                     , brick
                     , brick-panes
-                    , aeson >= 2.0 && < 2.2
+                    , aeson >= 2.0 && < 2.3
                     , bytestring
                     , containers
                     , directory
@@ -80,7 +80,7 @@ executable mywork-example
                     , text-zipper >= 0.12 && < 0.14
                     , time
                     , vector >= 0.12 && < 0.14
-                    , vty >= 5.35 && < 5.39
+                    , vty >= 5.35 && < 6.2
     if !flag(examples)
       buildable: False
 
@@ -92,7 +92,7 @@ test-suite brick-panes-test
     type:             exitcode-stdio-1.0
     hs-source-dirs:   test
     main-is:          Main.hs
-    build-depends:    base >= 4.13 && < 4.18
+    build-depends:    base >= 4.13 && < 5
                     , brick-panes
 
 


### PR DESCRIPTION
This PR is to bump up the brick versions along with the base.
I have build the brick-panes library locally with ghc 9.6.3 and cabal 3.10.2.0 and built the example as well and it did run successfully.
Please suggest changes to the PR if something does not seem right to you. This will be my first open source contribution.

Thanks